### PR TITLE
:sparkles:Feat: 빵판을 통한 LED 제어

### DIFF
--- a/ros2_ws/src/example/example/self_driving/self_driving.launch.py
+++ b/ros2_ws/src/example/example/self_driving/self_driving.launch.py
@@ -59,6 +59,15 @@ def launch_setup(context):
         parameters=[{'start': start}, {'only_line_follow': only_line_follow}],
     )
 
+    # LED 제어 노드 추가
+    led_controller_node = Node(
+        package='peripherals',
+        executable='led_controller',
+        name='led_controller',
+        parameters=[{'led_pin': 18}],
+        output='screen',
+    )
+
     return [start_arg,
             only_line_follow_arg,
             depth_camera_launch,
@@ -66,6 +75,7 @@ def launch_setup(context):
             #web_video_server_node,
             yolov5_node, 
             self_driving_node,
+            led_controller_node,   # 추가
             ]
 
 def generate_launch_description():

--- a/ros2_ws/src/example/example/self_driving/self_driving.py
+++ b/ros2_ws/src/example/example/self_driving/self_driving.py
@@ -27,6 +27,7 @@ from example.self_driving import lane_detect
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.callback_groups import ReentrantCallbackGroup
 from ros_robot_controller_msgs.msg import BuzzerState, SetPWMServoState, PWMServoState, RGBStates, RGBState
+from std_msgs.msg import Bool
 
 
 class SelfDrivingNode(Node):
@@ -67,6 +68,7 @@ class SelfDrivingNode(Node):
         self.servo_state_pub = self.create_publisher(SetPWMServoState, 'ros_robot_controller/pwm_servo/set_state', 1)
         self.result_publisher = self.create_publisher(Image, '~/image_result', 1)
         self.rgb_pub = self.create_publisher(RGBStates, '/ros_robot_controller/set_rgb', 1)
+        self.led_pub = self.create_publisher(Bool, '/led_cmd', 10)  # 브레드보드 LED 제어 퍼블리셔
 
         # [3] 서비스 생성
         self.create_service(Trigger, '~/enter', self.enter_srv_callback)
@@ -377,6 +379,7 @@ class SelfDrivingNode(Node):
                 self.tl_hold_until = now() + self.tl_min_stop
                 self.green_cnt = 0
                 self.set_rgb_color(255, 0, 0)
+                self.led_pub.publish(Bool(data=True))  # 빨간불 정지 시 LED ON
                 self.get_logger().info('\033[1;31m[TL] RED → STOP\033[0m')
 
         # 유지/해제
@@ -404,6 +407,7 @@ class SelfDrivingNode(Node):
                 self.red_cnt = 0
                 self.tl_hold_until = None
                 self.set_rgb_color(0, 255, 0)
+                self.led_pub.publish(Bool(data=False))  # 초록불 출발 시 LED OFF
                 self.get_logger().info('\033[1;32m[TL] GO (green)\033[0m')
                 # 여기서 정지 퍼블리시는 하지 않음 → 다음 로직이 자연스럽게 출발
             else:
@@ -487,6 +491,7 @@ class SelfDrivingNode(Node):
                             self.cw_state = 'stopping'
                             self.cw_ts = t
                             self.set_rgb_color(255, 0, 0)  # 정지 시작(빨강)
+                            self.led_pub.publish(Bool(data=True))  # 횡단보도 정지 시 LED ON
                             self.first_light_seen_ts = None
                             self.get_logger().info('\033[1;35m[CW] STOPPING start (3s)\033[0m')
 
@@ -529,6 +534,7 @@ class SelfDrivingNode(Node):
                                 self.cw_state = 'cooldown'
                                 self.cw_ts = t
                                 self.set_rgb_color(0, 255, 0)  # 출발 (초록)
+                                self.led_pub.publish(Bool(data=False))  # 횡단보도 출발 시 LED OFF
                                 # crosswalk_detected 플래그는 콜백에서 다시 갱신됨
                                 self.get_logger().info('\033[1;31m[CW] START IGNORE (cooldown 5s)\033[0m')
 

--- a/ros2_ws/src/peripherals/launch/led_controller.launch.py
+++ b/ros2_ws/src/peripherals/launch/led_controller.launch.py
@@ -1,0 +1,13 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='peripherals',
+            executable='led_controller',
+            name='led_controller',
+            parameters=[{'led_pin': 18}],   # ← GPIO 18번 사용
+            output='screen'
+        )
+    ])

--- a/ros2_ws/src/peripherals/peripherals/led_controller.py
+++ b/ros2_ws/src/peripherals/peripherals/led_controller.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Bool
+import lgpio  # RPi.GPIO 대신 lgpio 사용
+
+class LEDController(Node):
+    def __init__(self):
+        super().__init__('led_controller')
+
+        # === [1] GPIO 핀 설정 ===
+        self.declare_parameter('led_pin', 18)
+        self.led_pin = self.get_parameter('led_pin').get_parameter_value().integer_value
+
+        # gpiochip0 열기
+        self.chip = lgpio.gpiochip_open(0)
+        lgpio.gpio_claim_output(self.chip, self.led_pin)  # 출력 모드로 설정
+        lgpio.gpio_write(self.chip, self.led_pin, 0)      # 초기 상태 OFF
+
+        # === [2] ROS2 구독 설정 ===
+        self.subscription = self.create_subscription(
+            Bool,
+            '/led_cmd',
+            self.listener_callback,
+            10
+        )
+
+        self.get_logger().info(f"LED Controller started (GPIO {self.led_pin})")
+
+    def listener_callback(self, msg: Bool):
+        """LED ON/OFF 제어"""
+        lgpio.gpio_write(self.chip, self.led_pin, 1 if msg.data else 0)
+        state = "ON" if msg.data else "OFF"
+        self.get_logger().info(f"💡 LED {state} (GPIO {self.led_pin})")
+
+    def destroy_node(self):
+        """종료 시 자원 해제"""
+        lgpio.gpio_write(self.chip, self.led_pin, 0)
+        lgpio.gpiochip_close(self.chip)
+        super().destroy_node()
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = LEDController()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/ros2_ws/src/peripherals/setup.py
+++ b/ros2_ws/src/peripherals/setup.py
@@ -29,6 +29,7 @@ setup(
             'joystick_control = peripherals.joystick_control:main',
             'tf_broadcaster_imu = peripherals.tf_broadcaster_imu:main',
             'teleop_key_control = peripherals.teleop_key_control:main',
+            'led_controller = peripherals.led_controller:main',
         ],
     },
 )


### PR DESCRIPTION
## 📌 PR 요약
- 빵판을 통한 LED 제어
- GPIO 사용을 위한 패키지 설치 - `sudo apt install -y python3-lgpio`
- 노드 생성 확인 완료
```
❯ ros2 node list
/ascamera/camera_publisher
/led_controller  # 추가된 노드
/odom_publisher
/ros_robot_controller
/self_driving
/yolov5_ros2
```

## ✅ 체크리스트
- [x] 기능/노드 구현 완료
- [x] 로컬 환경 테스트 완료 (ex. rclpy, launch 실행 확인)
- [x] 시뮬레이션/하드웨어 테스트 완료 (필요 시)
- [x] 코드 스타일/컨벤션 준수 (ex. PEP8, 프로젝트 규칙)
- [x] 관련 이슈에 연결 (ex. Closes #이슈번호)

## 🔍 테스트 방법
- 빌드 : `colcon build --packages-select peripherals`
- 실행 : `ros2 launch example self_driving.launch.py start:=true only_line_follow:=false`


## 📎 참고 자료
- #19 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an LED controller node to reflect driving state via an onboard LED (on for stop, off for go), including crosswalk events.
  - Self-driving behavior now publishes LED commands to match traffic light and crosswalk state changes.
  - Launch configuration updated to include the LED controller; LED pin is configurable (default 18).

- Chores
  - Added a new executable entry point for the LED controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->